### PR TITLE
Update README.md

### DIFF
--- a/advanced/1. call-apply-bind-methods/README.md
+++ b/advanced/1. call-apply-bind-methods/README.md
@@ -61,7 +61,7 @@ function Person(fName, lName, age) {
 }
 
 function Student(fName, lName, age, roll, section) {
-  Person.call(this, fName, lName, age, roll, section);
+  Person.call(this, fName, lName, age);
   this._roll = roll;
   this._section = section;
 }


### PR DESCRIPTION
remove unused param from Person.call() method. Person function have **fName, IName, age** param.  Params **roll, section**
have no use in Person function. They already used in Student function.

function Person(fName, lName, age) {
  this._firstName = fName;
  this._lastName = lName;
  this._age = age;
}